### PR TITLE
Add TypeScript setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Glass Dashboard Setup
+
+This repository contains a React + TypeScript project generated from Figma assets.
+
+## Initializing TypeScript
+
+Run the provided script to generate a minimal `package.json` and `tsconfig.json`:
+
+```bash
+bash scripts/init-typescript.sh
+```
+
+This will run `npm init -y`, install TypeScript, and create a default `tsconfig.json` file.

--- a/file-structure.md
+++ b/file-structure.md
@@ -1,0 +1,34 @@
+# File Structure
+
+```
+./
+├── App.tsx
+├── ShowroomApp.tsx
+├── README.md
+├── components/
+│   ├── CustomerVideoPlayer.tsx
+│   ├── FeaturePlaceholder.tsx
+│   ├── MediaPlayer.tsx
+│   ├── NavigationButtons.tsx
+│   ├── ShowroomNavigationButtons.tsx
+│   ├── ShowroomVideoPlayer.tsx
+│   ├── TodaysAppointments.tsx
+│   ├── VehicleDetails.tsx
+│   ├── VideoPlayer.tsx
+│   ├── figma/
+│   └── ui/ (48 utility components)
+├── styles/
+│   └── globals.css
+├── types/
+│   └── index.ts
+└── utils/
+    └── shareUtils.ts
+├── scripts/
+│   └── init-typescript.sh
+```
+
+**Frameworks**
+- React with TypeScript
+- Tailwind CSS (via `tailwind-merge`)
+
+No backend or database code yet.

--- a/granular-plan.md
+++ b/granular-plan.md
@@ -1,0 +1,13 @@
+# Granular Plan
+
+## Module: Project Setup & Baseline
+- [ ] Review current React + TypeScript setup and confirm all components compile.
+- [ ] Document existing file structure in `file-structure.md`.
+- [ ] Prepare environment for Google API and PostgreSQL integration.
+- [ ] Add setup script `scripts/init-typescript.sh` to generate `package.json` and `tsconfig.json`.
+
+## New Conversation Prompt
+To continue work, run:
+```
+open master-plan.md and proceed with the next unchecked section. Follow tasks in granular-plan.md under "Module: Project Setup & Baseline".
+```

--- a/master-plan.md
+++ b/master-plan.md
@@ -1,0 +1,35 @@
+# Master Plan
+
+This document outlines the high-level roadmap for the Glass Dashboard project. It should only be modified when marking sections as complete at the end of a session.
+
+## Sections
+
+### 1. Project Setup & Baseline
+- Set up React + TypeScript workspace and integrate Figma assets.
+- Ensure Tailwind CSS is configured for styling.
+- Implement baseline components: video player, navigation buttons, media player, etc.
+
+### 2. Google Calendar Integration
+- Integrate Google Calendar API to display dealership appointments.
+- Show upcoming events in a dedicated component.
+
+### 3. PostgreSQL Database with Prisma
+- Configure PostgreSQL database.
+- Define `prisma.schema` for inventory and media items.
+- Implement Prisma client for data access.
+
+### 4. Inventory Slideshow
+- Fetch inventory data from the database.
+- Use navigation buttons to select vehicles/media as slideshow images or videos.
+
+### 5. Customer vs Showroom Views
+- Provide restricted customer view that only displays shared media.
+- Provide showroom view with full navigation.
+
+### 6. Shareable Media Links
+- Generate secure links that show specific media in customer view.
+- Prevent access to other areas when using a share link.
+
+### 7. Testing & Error Handling
+- Set up Jest and ESLint for tests and linting.
+- Add error handling for media and network operations.

--- a/scripts/init-typescript.sh
+++ b/scripts/init-typescript.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Initialize npm project with default values
+npm init -y
+
+# Install TypeScript as a dev dependency
+npm install --save-dev typescript
+
+# Generate tsconfig.json with default settings
+npx tsc --init
+
+echo "TypeScript project initialized."


### PR DESCRIPTION
## Summary
- provide README with TypeScript setup steps
- add init-typescript.sh script for creating package.json and tsconfig.json
- document new script in file-structure and granular plan

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm run lint` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685741fac724833087a7f4406d16cd17